### PR TITLE
fixed Attributes in Reboot Handler

### DIFF
--- a/lib/Kanku/Handler/Reboot.pm
+++ b/lib/Kanku/Handler/Reboot.pm
@@ -24,6 +24,11 @@ use Path::Class::File;
 use Data::Dumper;
 with 'Kanku::Roles::Handler';
 
+has [qw/
+      domain_name
+      login_user
+      login_pass
+/] => (is => 'rw',isa=>'Str');
 has [qw/wait_for_network wait_for_console/] => (is => 'rw',isa=>'Bool',lazy=>1,default=>1);
 has [qw/timeout/] => (is => 'rw',isa=>'Int',lazy=>1,default=>600);
 


### PR DESCRIPTION
fiixes missing attributes.
Error was: 

```
[2016/12/06 15:38:49][ERROR] Can't locate object method "domain_name" via package "Kanku::Handler::Reboot" at /opt/kanku/bin/../lib/Kanku/Handler/Reboot.pm line 50.
```