### PR TITLE
[setup] Do not overwrite qemu.conf backup

### DIFF
--- a/lib/Kanku/Setup/Roles/Common.pm
+++ b/lib/Kanku/Setup/Roles/Common.pm
@@ -106,9 +106,6 @@ EOF
 
   return unless $choice;
 
-  my $conf = file('/etc/libvirt/qemu.conf');
-  $self->_backup_config_file($conf);
-
   my $dconf = file('/etc/libvirt/libvirtd.conf');
 
   my @lines = $dconf->slurp;


### PR DESCRIPTION
Without this patch, `kanku setup --devel` does
```
[2019/05/25 11:11:05][DEBUG](1830) Create backup of config /etc/libvirt/qemu.conf -> /etc/libvirt/qemu.conf.kanku-bak1558775465.1830
[2019/05/25 11:11:05][DEBUG](1830) Create backup of config /etc/libvirt/qemu.conf -> /etc/libvirt/qemu.conf.kanku-bak1558775465.1830
```

and has the backup identical to the modified qemu.conf
And there is no copy of the original left.

Note: not tested.