### PR TITLE
for nsca send WARNING for a failed test and UNKNOWN for unknown status

### DIFF
--- a/lib/Kanku/Notifier/NSCA.pm
+++ b/lib/Kanku/Notifier/NSCA.pm
@@ -80,9 +80,9 @@ sub notify {
   if($self->state eq 'succeed') {
     $nstat = $Net::NSCA::Client::STATUS_OK;
   } elsif ($self->state eq 'failed') {
-    $nstat = $Net::NSCA::Client::STATUS_CRITICAL;
-  } else {
     $nstat = $Net::NSCA::Client::STATUS_WARNING;
+  } else {
+    $nstat = $Net::NSCA::Client::STATUS_UNKNOWN;
   }
 
   $self->logger->debug("Sending report (status: $nstat  with message: ".$self->short_message);


### PR DESCRIPTION
what do you think, I'd say WARNING is enough for a failed testcase and if it's not "ok" or "failed" it's IMHO "unknown"