### PR TITLE
[examples] add KankuFile.openSUSE-Leap-15.5-official

### DIFF
--- a/KankuFile.examples/KankuFile.openSUSE-Leap-15.5-official
+++ b/KankuFile.examples/KankuFile.openSUSE-Leap-15.5-official
@@ -1,0 +1,110 @@
+domain_name: kanku-example-1
+default_job: kanku-job
+login_user: root
+
+################################################################################
+# This password needs to be the same as used in 
+# Kanku::Handler::CreateDomain->options->installation->...
+################################################################################
+login_pass: linux
+
+jobs:
+ kanku-job:
+  -
+    use_module: Kanku::Handler::SetJobContext
+    options:
+      host_interface: eth0
+  ##############################################################################
+  #
+  # We dont need Kanku::Handler::OBSCheck here as we use a static link
+  # in the next handler (Kanku::Handler::ImageDownload) to
+  # https://download.opensuse.org/....
+  #
+  #-
+  #  use_module: Kanku::Handler::OBSCheck
+  #  options:
+  #    api_url: https://api.opensuse.org/public
+  #    project: openSUSE:Leap:15.5:Images
+  #    # `:kvm-and-xen` is the _multibuild flavor of the package
+  #    package: kiwi-templates-Minimal:kvm-and-xen
+  #    repository: images
+  #    arch: x86_64
+  #    # skip_check_project is required because publishing is disabled
+  #    skip_check_project: 1
+  ##############################################################################
+  -
+    use_module: Kanku::Handler::ImageDownload
+    options:
+      ##########################################################################
+      # Here we need to specify the static link URL as no OBSCheck is involved
+      ##########################################################################
+      url: https://download.opensuse.org/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-kvm-and-xen.qcow2
+  -
+    use_module: Kanku::Handler::CreateDomain
+    options:
+      memory: 2G
+      vcpu: 1
+      use_9p: 1
+      ##########################################################################
+      # pwrand: # OPTIONAL BUT STRONGLY RECOMMENDED
+      #   users: # List of users inside the VM to set a randomized password for
+      #     - root
+      #   recipients: # List of mail addresses to encrypt the passwords for
+      #     - fschreiner@suse.de
+      ##########################################################################
+
+      ##########################################################################
+      # The with-spice template is required to 
+      # get a proper redirection of the serial
+      # console
+      ##########################################################################
+      template: with-spice
+
+      ##########################################################################
+      # The following `installation` section is required to automize the
+      # interactive bootstrapping process.
+      ##########################################################################
+      installation:
+        -
+          expect: Welcome
+          send_enter: 1
+        -
+          expect: Select keyboard layout
+          send_enter: 1
+        -
+          expect: LICENSE AGREEMENT
+          send_enter: 1
+        -
+          expect: Select time zone
+          send_enter: 1
+        ########################################################################
+        # The strings to send in following 2 entries need to be the same as in
+        #
+        # login_pass:
+        #
+        # at the beginning of this file
+        ########################################################################
+        -
+          expect: Enter root password
+          send: linux
+          send_enter: 1
+        -
+          expect: Confirm root password
+          send: linux
+          send_enter: 1
+
+  ##############################################################################
+  # Deployment of openssh-server and authorized_keys as configured in your 
+  # profile (or guessed - e.g. ssh public keys)
+  ##############################################################################
+  -
+    use_module: Kanku::Handler::PrepareSSH
+
+  ##############################################################################
+  # Testing results of Kanku::Handler::PrepareSSH 
+  ##############################################################################
+  -
+    use_module: Kanku::Handler::ExecuteCommandViaSSH
+    options:
+      commands:
+        - echo "Just checking ssh connnection and key deployment"


### PR DESCRIPTION
This patch adds a documented KankuFile to use one of the "official" openSUSE images which can be found under https://download.opensuse.org/distribution/leap/15.5/appliances/